### PR TITLE
Successfully showing user rating on movie card when user is signed in

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -107,11 +107,11 @@ class App extends Component {
 //   return (
 //     <main>
 //         <Switch>
-//             <Route exact path="/" render= {() => { 
+//             <Route exact path="/" render= {() => {
 //               return <Login />;}
 //             }
 //               exact />
-//             <Route path="/movie" render= {() => { 
+//             <Route path="/movie" render= {() => {
 //               return <MovieData />;}
 //             }
 //             exact />

--- a/src/MovieData/MovieData.js
+++ b/src/MovieData/MovieData.js
@@ -18,29 +18,19 @@ class MovieData extends Component {
     };
   }
 
-  // async componentDidMount() {
-  //   let data = await movieDataFetch()
-  //   let ratings = await getRatings(this.props.user.id)
-  //   console.log("DATA", data)
-  //   console.log("RATING", ratings)
-  //   if (this.props.user.id > 0) {
-  //     return  movieMatch = ratings.find(rating => {
-  //       return movie.id === rating.movie_id
-  //     })
-  //   })
-  // }
 
   async componentDidMount() {
     let data = await movieDataFetch()
-    let ratings = await getRatings(this.props.user.id)
+    .then(data => this.setState({ movies: data.movies }))
     .catch((error) => console.log(error));
     console.log("DATA", data)
-    console.log("RATING", ratings)
+    //console.log("RATING", ratings)
     // .catch(error => console.log('DEATH'))
 
 
     if (this.props.user.id > 0) {
-      const newMovieMatch = data.movies.map(movie => {
+      let ratings = await getRatings(this.props.user.id)
+      const newMovieMatch = this.state.movies.map(movie => {
         let movieMatch = ratings.ratings.find(info => {
           return info.movie_id == movie.id
         })
@@ -52,61 +42,13 @@ class MovieData extends Component {
       }
   }
 
-  //   aysnc componentDidMount() {
-  //   await movieDataFetch()
-  //   .then((data) => this.setState({ movies : data.movies })
-  //   .then(() => await getRatings(this.props.user.id))
-  //
-  // }
-
-
-
-
-
-
-
-
-
-      // .catch(error => this.setState({ error }))
-
-
-      //if movie has not been rated the default should be zero
-      //combine the two arrays together and set the state based on the two arrays
-
-
-
-
-
-
-  // setUserRating(){
-  //   getRatings(userIDFrom another class)
-  //   .then(response => {
-  //     return response
-  //   })
-  //   .then(data => {this.setState({ movies : data.movies })
-  //   })
-  //   .catch(error => this.setState({ error }))
-  // }
-
   render() {
-    // let myRating = this.state.userRating;
-
-
-
-
-    // console.log("1", this.state.movies.movieRating)
-    // console.log("S", this.state.movies[0].movieRating)
-
-    // console.log("LOG", this.state.movies.movieRating.rating)
-    // let specificRating = this.state.movies ? this.state.movies.movieRating.rating : 0
-    // this.eventHandler()
     return (
       <main>
       <div className='movie-cards'>
         {this.state.movies.map((movie, index) => {
         const thisID = movie.id;
         let showUserRating;
-        console.log("AAAAAA", this.state.movies)
         if (movie.movieRating) {
           showUserRating = movie.movieRating.rating
         } else {
@@ -122,7 +64,7 @@ class MovieData extends Component {
             </p>
             <img className='movie-poster' alt='movie-poster' src={movie.poster_path} />
             <h1 className='movie-rating'>Average Rating: {movie.average_rating.toFixed(1)}/10</h1>
-            <h1 className='movie-rating' >My Rating: {showUserRating}</h1>
+            <h1 className='movie-rating' style={{ display: this.props.user.id > 0 ? 'block' : 'none' }}>My Rating: {showUserRating}</h1>
             <Link to={'/showpage/'+thisID} className='movie-link'>Movie Details</Link>
           </section>
         )


### PR DESCRIPTION
### Code Highlights:
* Participating Group Member(s): Katy and KJ
* Iteration Number: 4
* Goal: Show user ratings whenever a movie is shown on the site.

   * [This branch](https://github.com/kathrynljackson/Rancid-Tomatillos-KK/tree/ratings-ks) showed the user rating on the movie card when a user was signed in, but did not show any movies if a user was not signed in. 
   * We spoke with our instructor, @khalidwilliams, during our project check-in and he suggested separating the functions like we did in `ShowPage`. I tried this multiple times, but this was an easier refactor given that many values and props were being used in `MovieData`. Given more time, I would rather the functions be separated, but the functionality is more important for the sake of progression.

### Next Steps:
* add rating deletion functionality

### Problems or Challenges:
* `getRatings()` was being called in `MovieData` whether or not there was a user, preventing the page from rendering properly. 

### Issues: 
* Closes #38 
* Closes #39 

### Screenshots (if appropriate): 

<img width="982" alt="Screen Shot 2020-10-19 at 6 36 28 PM" src="https://user-images.githubusercontent.com/65988644/96526138-04087b80-123a-11eb-9d8e-ecd264cda6a6.png">


### Tracking Consistency:
- [x] checked functionality of the webpage and included details above
- [x] received help from a mentor/collaborator
- [x] added classmate as reviewers
- [ ] added instructors as reviewers
- [x] added appropriate tags
- [x] looked at PR preview to check spelling, syntax, and formatting
